### PR TITLE
Changed environment from production to development. Now we can use NT…

### DIFF
--- a/backend/portal/auth_app/views.py
+++ b/backend/portal/auth_app/views.py
@@ -29,7 +29,7 @@ class LoginView(views.APIView):
         }
 
         response = requests.post(
-            f'{settings.NTNUI_API_URL}/token/',
+            f'{settings.NTNUI_DEV_API_URL}/token/',
             data=payload,
         )
 

--- a/backend/portal/portal/settings.py
+++ b/backend/portal/portal/settings.py
@@ -146,4 +146,4 @@ SIMPLE_JWT = {
     # ... any other JWT settings you want to override
 }
 
-NTNUI_API_URL = 'https://api.ntnui.no'  # Replace with actual API URL
+NTNUI_DEV_API_URL = 'https://dev.api.ntnui.no'  # Replace with actual API URL

--- a/clients/ntnui_client/app.js
+++ b/clients/ntnui_client/app.js
@@ -32,7 +32,7 @@ app.get("/auth/callback", function (req, res) {
     var accessToken = req.cookies["access_token"];
 
     axios
-      .get("https://api.ntnui.no/users/profile/", {
+      .get("https://dev.api.ntnui.no/users/profile/", {
         headers: { Authorization: "Bearer " + accessToken },
       })
       .then(function (response) {


### PR DESCRIPTION
…NUI test users, e.g. 'Sprint Sprint' instead of actuall NTNUI users.